### PR TITLE
Do not require the IOE effect

### DIFF
--- a/src/Effectful/PostgreSQL/Transact.hs
+++ b/src/Effectful/PostgreSQL/Transact.hs
@@ -3,48 +3,48 @@ module Effectful.PostgreSQL.Transact where
 import qualified Database.PostgreSQL.Transact as DBT
 import Effectful.PostgreSQL.Transact.Effect
 import Database.PostgreSQL.Simple (Query, ToRow, FromRow)
-import Effectful (Effect, type (:>), Eff, IOE)
+import Effectful (Effect, type (:>), Eff)
 import Data.Kind (Type)
 import Data.Int (Int64)
 
 query :: forall (es :: [Effect]) (parameters :: Type) (b :: Type).
-         (IOE :> es, DB :> es, ToRow parameters, FromRow b)
+         (DB :> es, ToRow parameters, FromRow b)
       => Query
-      -> parameters 
+      -> parameters
       -> Eff es [b]
 query q parameters = dbtToEff $ DBT.query q parameters
 
-query_ :: forall (es :: [Effect]) (b :: Type). (IOE :> es, DB :> es, FromRow b)
+query_ :: forall (es :: [Effect]) (b :: Type). (DB :> es, FromRow b)
       => Query
       -> Eff es [b]
-query_ q = dbtToEff $ DBT.query_ q 
+query_ q = dbtToEff $ DBT.query_ q
 
 queryOne :: forall (es :: [Effect]) (parameters :: Type) (b :: Type).
-         (IOE :> es, DB :> es, ToRow parameters, FromRow b)
+         (DB :> es, ToRow parameters, FromRow b)
       => Query
-      -> parameters 
+      -> parameters
       -> Eff es (Maybe b)
 queryOne q parameters = dbtToEff $ DBT.queryOne q parameters
 
 queryOne_ :: forall (es :: [Effect]) (b :: Type).
-         (IOE :> es, DB :> es, FromRow b)
+         (DB :> es, FromRow b)
       => Query
       -> Eff es (Maybe b)
-queryOne_ q = dbtToEff $ DBT.queryOne_ q 
+queryOne_ q = dbtToEff $ DBT.queryOne_ q
 
 
-execute :: forall (es :: [Effect]) (parameters :: Type). (ToRow parameters, IOE :> es, DB :> es)
+execute :: forall (es :: [Effect]) (parameters :: Type). (ToRow parameters, DB :> es)
         => Query
         -> parameters
         -> Eff es Int64
 execute q parameters = dbtToEff $ DBT.execute q parameters
 
-execute_ :: forall (es :: [Effect]). (IOE :> es, DB :> es)
+execute_ :: forall (es :: [Effect]). (DB :> es)
         => Query
         -> Eff es Int64
-execute_ q = dbtToEff $ DBT.execute_ q 
+execute_ q = dbtToEff $ DBT.execute_ q
 
-executeMany :: forall (es :: [Effect]) (parameters :: Type). (ToRow parameters, IOE :> es, DB :> es)
+executeMany :: forall (es :: [Effect]) (parameters :: Type). (ToRow parameters, DB :> es)
             => Query
             -> [parameters]
             -> Eff es Int64

--- a/src/Effectful/PostgreSQL/Transact/Effect.hs
+++ b/src/Effectful/PostgreSQL/Transact/Effect.hs
@@ -38,10 +38,10 @@ getPool = do
 --   pool <- DBT.getConnection
 --   liftIO . runEff . runDB pool $ computation
 
-dbtToEff :: (DB :> es, IOE :> es)
+dbtToEff :: (DB :> es)
          => DBT IO a
          -> Eff es a
 dbtToEff (DBT dbtComputation) = do
   DB pool <- getStaticRep
-  liftIO $ Pool.withResource pool $ \conn -> 
+  unsafeEff_ $ Pool.withResource pool $ \conn ->
     runReaderT dbtComputation conn


### PR DESCRIPTION
This PR makes the constraints on the effect row more precise.
Consider the following two type signatures:
```haskell
foo :: (DB :> es) => Int -> String -> Eff es ()
bar :: (IOE :> es, DB :> es) => Int -> String -> Eff es ()
```
So what do we know about `foo` and `bar`? We can be sure that `foo` does read or modify our database but nothing else. The same cannot be said about `bar`: Does it write to the filesystem in addition to the database actions? Does it launch rockets? We cannot know unless we look at the definition. So, while using `unsafeEff_`  instead of `liftIO` removes the `IOE` effect of the different this does not hurt safety as the `DB` effect itself implies `IOE` as we need to call `runDB` eventually.